### PR TITLE
fix: types are no longer constrained to container classes

### DIFF
--- a/examples/strong-typed/complex-subset.ts
+++ b/examples/strong-typed/complex-subset.ts
@@ -8,9 +8,10 @@ type MyParameters = {
   'title.sir': string;
 };
 
-type MyContainer = ServiceContainer<MyServices, MyParameters>;
+type MyContainerInstance = ServiceContainer<MyServices, MyParameters>;
+type MyContainer = Container.Definition.Make<MyContainerInstance>;
 
-const container: MyContainer = new ServiceContainer(
+const container: MyContainerInstance = new ServiceContainer(
   {
     'title.sir': () => 'Sir',
   },

--- a/examples/strong-typed/complex.ts
+++ b/examples/strong-typed/complex.ts
@@ -64,8 +64,10 @@ const services: Container.Service.Definition<ServiceParameters, Services> = {
   },
 };
 
-type MyContainer = ServiceContainer<Services, ServiceParameters, EnvironmentVariables>;
-const container: MyContainer = new ServiceContainer(parameters, services);
+type MyContainerInstance = ServiceContainer<Services, ServiceParameters, EnvironmentVariables>;
+type MyContainer = Container.Definition.Make<MyContainerInstance>;
+
+const container: MyContainerInstance = new ServiceContainer(parameters, services);
 
 type MyHandler = (name: string) => { alive: boolean; greeting?: string; };
 type MyHandlerContainerAware = Container.MakeAware<MyContainer, MyHandler>;


### PR DESCRIPTION
Fixes an issue where types would not work when using the class types. This was caused by a last-minute refactor that removed the inheritance used by the `ServiceContainer`. Now the types have no reliance on the classes (as types) and a concept of "definition" has been introduced instead.